### PR TITLE
Don't use \n characters in the test output

### DIFF
--- a/testutils/spec.nim
+++ b/testutils/spec.nim
@@ -94,7 +94,7 @@ proc rewriteTestFile*(spec: TestSpec; outputs: TestOutputs) =
   # add the new test outputs
   for name, expected in outputs.pairs:
     test.setSectionKey(spec.section, name, expected)
-  test.writeConfig(spec.path)
+  writeFile spec.path, ($test).replace("\\n", "\n")
 
 proc parseTestFile*(filePath: string; config: TestConfig): TestSpec =
   ## parse a test input file into a spec


### PR DESCRIPTION
The multi-line form is considered more human readable, but more
importantly there seems to be a problem with the espaced new lines.
The Chronicles tests that include multi-line output are failing
without this change.