### PR TITLE
Add markdown test report module

### DIFF
--- a/testutils/markdown_reports.nim
+++ b/testutils/markdown_reports.nim
@@ -1,0 +1,44 @@
+import algorithm, sequtils, strutils, strformat, tables
+
+type
+  Status* {.pure.} = enum OK, Fail, Skip
+
+proc generateReport*(title: string; data: OrderedTable[string, OrderedTable[string, Status]];
+                     width = 63) =
+  ## Generate a markdown report from test data and write it to a file with the given title.
+  ## The table keys are sections, and the nested tables map tests to statuses.
+  let symbol: array[Status, string] = ["+", "-", " "]
+  var raw = ""
+  var okCountTotal = 0
+  var failCountTotal = 0
+  var skipCountTotal = 0
+  raw.add(title & "\n")
+  raw.add("===\n")
+  for section, statuses in data:
+    raw.add("## " & section & "\n")
+    raw.add("```diff\n")
+    var sortedStatuses = statuses
+    sortedStatuses.sort do (a: (string, Status), b: (string, Status)) -> int:
+      cmp(a[0], b[0])
+    var okCount = 0
+    var failCount = 0
+    var skipCount = 0
+    for name, final in sortedStatuses:
+      let padded = alignLeft(name, width)
+      raw.add(&"{symbol[final]} {padded[0 ..< width]} {$final}\n")
+      case final
+      of Status.OK: okCount += 1
+      of Status.Fail: failCount += 1
+      of Status.Skip: skipCount += 1
+    raw.add("```\n")
+    let sum = okCount + failCount + skipCount
+    okCountTotal += okCount
+    failCountTotal += failCount
+    skipCountTotal += skipCount
+    raw.add("OK: $1/$4 Fail: $2/$4 Skip: $3/$4\n" % [$okCount, $failCount, $skipCount, $sum])
+
+  let sumTotal = okCountTotal + failCountTotal + skipCountTotal
+  raw.add("\n---TOTAL---\n")
+  raw.add("OK: $1/$4 Fail: $2/$4 Skip: $3/$4\n" % [$okCountTotal, $failCountTotal,
+                                                   $skipCountTotal, $sumTotal])
+  writeFile(title & ".md", raw)


### PR DESCRIPTION
First step towards https://github.com/status-im/nim-beacon-chain/issues/744. Code copied and slightly modified from https://github.com/status-im/nimbus/blob/a70c9d5e10f66b57a1ac3c9a965a26155d7f5d30/tests/test_helpers.nim#L111-L148
Tested with nimbus and nim-beacon-chain (https://github.com/status-im/nim-beacon-chain/pull/794). I'm not sure about the docstring, but it's something. 

To accommodate for nim-beacon-chain's much longer and inconsistent test names, I changed the padding logic to also cut off names above the given length. The magic 63 number is based on Nimbus's current minimum width of 64, which always included an extra space since the json files are just below that length. With test names longer than 64 characters, it leads to lines like:
`+ DEPOSIT_CONTRACT_ADDRESS                          "0x1234567890OK`
There's no space between the name and the status, so I just added a space in the formatting line. I could set it to 64, but then all the test diffs would get updated for Nimbus, and I figured that wouldn't be optimal.

I'm also unsure about whether this proc should write the file or just return the string, but I couldn't think of any reason to do that besides testing purposes, but working with files is fine in that case anyway.