### PR TITLE
Update fuzzing_engines.nim

### DIFF
--- a/testutils/fuzzing_engines.nim
+++ b/testutils/fuzzing_engines.nim
@@ -1,4 +1,4 @@
-import strformat, ospaths
+import strformat, os
 
 const
   aflGcc = "--cc=gcc " &


### PR DESCRIPTION
I am working on removing old deprecated stuff from Nim, like pre- `1.0` or so,
your package is on important packages list and still uses Deprecated `ospaths`.
:)
