### PR TITLE
update GitHub Actions CI images from deprecated Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos

--- a/tests/hello/hello_size.test
+++ b/tests/hello/hello_size.test
@@ -1,5 +1,5 @@
 program = "../hello"
-max_size = 101000
+max_size = 102000
 release
 --opt:size
 os = "linux,macosx"

--- a/tests/hello/hello_size.test
+++ b/tests/hello/hello_size.test
@@ -1,5 +1,5 @@
 program = "../hello"
-max_size = 100000
+max_size = 101000
 release
 --opt:size
 os = "linux,macosx"


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6002

The Ubuntu 20.04/Nim 1.4 combination produces a slightly larger hello world too:
```
file size is too large: 101408 > 101000
compiler: --verbosity:1 --warnings:on --skipUserCfg:on  --opt:size   --threads:on --define:release /home/runner/work/nim-testutils/nim-testutils/tests/hello.nim
[FAILED] compiled ../hello for hello_size 0.000 s
```