### PR TITLE
Add support for Dr.Chaos

### DIFF
--- a/testutils.nimble
+++ b/testutils.nimble
@@ -10,7 +10,8 @@ bin           = @["ntu"]
 #srcDir        = "testutils"
 
 requires "nim >= 1.2.0",
-         "unittest2"
+         "unittest2",
+         "drchaos"
 
 proc execCmd(cmd: string) =
   echo "execCmd: " & cmd

--- a/testutils/fuzzing.nim
+++ b/testutils/fuzzing.nim
@@ -103,6 +103,20 @@ template test*(body: untyped): untyped =
 
       fuzzerCall()
 
+when defined(llvmFuzzer):
+  import drchaos/mutator
+
+  template test*(typ: typedesc, body: untyped): untyped =
+    ## Test block to do the actual test that will be fuzzed in a loop.
+    ##
+    ## Within this test block there is access to the structured input `typ`
+    ## which contains the payload provided by the fuzzer.
+    mixin initImpl
+    initImpl()
+    func fuzzTarget(payload {.inject.}: typ) =
+      body
+    mutatorImpl(fuzzTarget, myMutator, typ)
+
 when defined(clangfast) and not defined(llvmFuzzer):
   ## Can be used for deferred instrumentation.
   ## Should be placed on a suitable location in the code where the delayed

--- a/testutils/fuzzing_engines.nim
+++ b/testutils/fuzzing_engines.nim
@@ -25,7 +25,7 @@ const
 
   # Can also test in debug mode obviously, but might be slower
   # Can turn on more logging, in case of libFuzzer it will get very verbose though
-  defaultFlags = "-d:release -d:chronicles_log_level=fatal " &
+  defaultFlags = "-d:release -d:useMalloc -g -d:chronicles_log_level=fatal " &
                  "--hints:off --warnings:off --verbosity:0"
 
 type
@@ -96,7 +96,7 @@ proc aflExec*(target: string,
   exec fuzzCmd
 
 proc libFuzzerCompile*(target: string) =
-  let libFuzzerOptions = &"-d:llvmFuzzer --noMain {libFuzzerClang}"
+  let libFuzzerOptions = &"-d:llvmFuzzer -d:noSignalHandler --noMain {libFuzzerClang}"
   let compileCmd = &"nim c {defaultFlags} {libFuzzerOptions} {q target}"
   exec compileCmd
 
@@ -108,7 +108,7 @@ proc libFuzzerExec*(target: string, corpusDir: string) =
   exec &"{q target} {q corpusDir}"
 
 proc honggfuzzCompile*(target: string) =
-  let honggfuzzOptions = &"-d:llvmFuzzer --noMain {honggfuzzClang}"
+  let honggfuzzOptions = &"-d:llvmFuzzer -d:noSignalHandler --noMain {honggfuzzClang}"
   let compileCmd = &"nim c {defaultFlags} {honggfuzzOptions} {q target}"
   exec compileCmd
 


### PR DESCRIPTION
Requires latest drchaos version (0.1.2). It includes the post-processor but that can be removed if needed.