### PR TITLE
allow `programMain` to throw

### DIFF
--- a/testutils/moduletests.nim
+++ b/testutils/moduletests.nim
@@ -14,7 +14,7 @@ template tests*(body: untyped) =
       payload()
 
 template programMain*(body: untyped) {.dirty.} =
-  proc main =
+  proc main {.raises: [CatchableError].} =
     body
 
   when isMainModule and not defined(testutils_test_build):


### PR DESCRIPTION
Annotate `programMain` wrapper `proc` with `{.raises: [CatchableError]}` to allow it to raise exceptions explicitly.