### PR TITLE
v0.5.3

### DIFF
--- a/testutils.nimble
+++ b/testutils.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "testutils"
-version       = "0.5.0"
+version       = "0.5.3"
 author        = "Status Research & Development GmbH"
 description   = "A unittest framework"
 license       = "Apache License 2.0"


### PR DESCRIPTION
v0.5.2 was not properly reflected in `testutils.nimble`. Create another release that properly bumps the version so that other projects pull the latest version.