### PR TITLE
Updated to Nimble config (version 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 nimcache/
 nimble.paths
+nimble.develop

--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,4 @@
-# begin Nimble config (version 1)
-when fileExists("nimble.paths"):
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config


### PR DESCRIPTION
## Problem

As described in #60, importing this package leads to an error `/root/.nimble/pkgcache/githubcom_statusimnimtestutils_0.7.0/config.nims(3, 11) Error: cannot open file: nimble.paths`  

## Solution

As suggested by @arnetheduck, this PR is the result of running `nimble setup` -- which updates `config.nim` to the latest version. The change appears to resolve the issue.  