### PR TITLE
Restore runner

### DIFF
--- a/ntu.nim
+++ b/ntu.nim
@@ -262,6 +262,26 @@ proc execute(test: TestSpec): TestStatus =
           # and we want any dependent testing to proceed as usual.
           result = SKIPPED
 
+proc executeAll(test: TestSpec): TestStatus =
+  ## run a test and any dependent children, yielding a single status
+  when compileOption("threads"):
+    try:
+      var
+        thread: TestThread
+      # we spawn and join the test here so that it can receive
+      # cpu affinity via the standard thread.pinToCpu method
+      discard thread.spawnTest(test, 0)
+      thread.joinThreads
+    except:
+      # any thread(?) exception is a failure
+      result = FAILED
+  else:
+    # unthreaded serial test execution
+    result = SKIPPED
+    while test != nil and result in {OK, SKIPPED}:
+      result = test.execute
+      test = test.child
+
 proc threadedExecute(payload: ThreadPayload) {.thread.} =
   ## a thread in which we'll perform a test execution given the payload
   var
@@ -309,6 +329,19 @@ proc scanTestPath(path: string): seq[string] =
     for file in walkDirRec path:
       if file.endsWith ".test":
         result.add file
+
+proc test(test: TestSpec; backend: string): TestStatus =
+  let
+    config = test.config
+  var
+    duration: float
+
+  try:
+    time duration:
+      # perform all tests in the test file
+      result = test.executeAll
+  finally:
+    logResult(test.name, result, duration)
 
 proc buildBackendTests(config: TestConfig;
                        tests: seq[TestSpec]): BackendTests =

--- a/testutils/fuzzing_engines.nim
+++ b/testutils/fuzzing_engines.nim
@@ -1,5 +1,5 @@
 import strformat
-import os
+import os except dirExists
 
 const
   aflGcc = "--cc=gcc " &
@@ -43,7 +43,7 @@ const
   defaultFuzzingEngine* = libFuzzer
 
 when not defined(nimscript):
-  import osproc
+  import os, osproc
 
   template exec(cmd: string) =
     discard execCmd(cmd)
@@ -133,7 +133,7 @@ proc honggfuzzExec*(target: string, corpusDir: string, outputDir: string) =
 
 proc runFuzzer*(targetPath: string, fuzzer: FuzzingEngine, corpusDir: string) =
   let
-    (path, target, _) = splitFile(targetPath)
+    (path, target, ext) = splitFile(targetPath)
     compiledExe = addFileExt(path / target, ExeExt)
     corpusDir = if corpusDir.len > 0: corpusDir
                 else: path / "corpus"

--- a/testutils/helpers.nim
+++ b/testutils/helpers.nim
@@ -79,7 +79,7 @@ proc parseCompileStream*(p: Process, output: Stream): CompileInfo =
        suc = line
 
       if err != "":
-       result.fullMsg.add(line & "\p")
+       result.fullMsg.add(line.string & "\p")
     else:
      result.exitCode = peekExitCode(p)
      if result.exitCode != -1:


### PR DESCRIPTION
The unit test runner was accidentally removed in https://github.com/status-im/nim-testutils/pull/57 and https://github.com/status-im/nim-testutils/pull/16/files#diff-c84421cbc49dd01500eb4ae034f4858e33c95a7d813f91745720ec5a06e53ac3L405 - this restores support.

Parallel running is disabled due to a bug in https://github.com/status-im/nim-testutils/pull/8 causing the runner to crash.