### PR TITLE
macOS support for install_honggfuzz.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,3 +9,39 @@ on:
 jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
+
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: linux
+          - os: macos
+        include:
+          - target:
+              os: linux
+            builder: ubuntu-latest
+          - target:
+              os: macos
+            builder: macos-latest
+
+    name: '${{ matrix.target.os }} Fuzz'
+    runs-on: ${{ matrix.builder }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install engines (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang afl++
+          bash scripts/install_honggfuzz.sh
+          echo "/opt/honggfuzz/usr/local/bin" >> "$GITHUB_PATH"
+
+      - name: Install engines (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm afl++
+          bash scripts/install_honggfuzz.sh
+          echo "/opt/honggfuzz/usr/local/bin" >> "$GITHUB_PATH"

--- a/scripts/install_honggfuzz.sh
+++ b/scripts/install_honggfuzz.sh
@@ -2,16 +2,39 @@
 
 set -eu
 
-sudo apt-get update
-sudo apt-get install binutils-dev
-sudo apt-get install libunwind8-dev
+SRC="${HONGGFUZZ_SRC:-/tmp/honggfuzz}"
+DESTDIR="${DESTDIR:-/opt/honggfuzz}"
+SUDO="${SUDO-sudo}"
 
-git clone https://github.com/google/honggfuzz.git /tmp/honggfuzz
+rm -rf "$SRC"
+git clone --depth 1 https://github.com/google/honggfuzz.git "$SRC"
 
-pushd /tmp/honggfuzz
-  make
-  sudo make install DESTDIR=/opt/honggfuzz
-popd
+case "$(uname -s)" in
+  Linux)
+    $SUDO apt-get update
+    $SUDO apt-get install -y binutils-dev libunwind8-dev
+    make -C "$SRC"
+    $SUDO make -C "$SRC" install DESTDIR="$DESTDIR"
+    ;;
+  Darwin)
+    # On macOS only the compiler wrappers (hfuzz-clang, ...) and libhfuzz works.
+    # Coverage-guided fuzzing links no longer existing private macOS frameworks.
+    sed -i '' 's/\$(error Unsupported MAC OS X version)/CRASH_REPORT := unsupported/' "$SRC/Makefile"
+    sed -i '' 's/-Wall -Wextra -Werror /-Wall -Wextra -Werror -Wno-error=strict-prototypes -Wno-error=c23-extensions -Wno-error=unused-command-line-argument /' "$SRC/Makefile"
+    printf '\n.PHONY: wrappers\nwrappers: $(HFUZZ_CC_BIN)\n' >> "$SRC/Makefile"
+    make -C "$SRC" wrappers LDFLAGS=
+    BIN_PATH="$DESTDIR/usr/local/bin"
+    $SUDO mkdir -p -m 755 "$BIN_PATH"
+    for w in hfuzz-cc hfuzz-clang hfuzz-clang++ hfuzz-gcc hfuzz-g++; do
+      $SUDO install -m 755 "$SRC/hfuzz_cc/$w" "$BIN_PATH"
+    done
+    echo "honggfuzz compiler wrappers installed to $BIN_PATH"
+    echo "Add to PATH:  export PATH=\"$BIN_PATH:\$PATH\""
+    ;;
+  *)
+    echo "$0: unsupported OS '$(uname -s)'" >&2
+    exit 1
+    ;;
+esac
 
-rm -rf /tmp/honggfuzz
-
+rm -rf "$SRC"


### PR DESCRIPTION
The current honggfuzz installer script only works on Linux, extend it to also work on macOS, with the given restriction that only the compiler wrapper works, but that fuzzing has to be guided manually.