### PR TITLE
Document stew dependency

### DIFF
--- a/testutils.nimble
+++ b/testutils.nimble
@@ -10,6 +10,7 @@ bin           = @["ntu"]
 #srcDir        = "testutils"
 
 requires "nim >= 1.6.0",
+         "stew",
          "unittest2"
 
 proc execCmd(cmd: string) =


### PR DESCRIPTION
fuzzing.nim imports stew/ptrops, but the nimble file doesn't declare it.